### PR TITLE
requisição de dividendos de fii com número de meses (n) > 100

### DIFF
--- a/fetch/fetch_fii.go
+++ b/fetch/fetch_fii.go
@@ -381,7 +381,7 @@ func (fii *FII) reportIDs(rt repType, code string, n int) ([]id, error) {
 		"l":                    []string{"200"}, // 'n*2' latest reports as other codes may appear (e.g.:ABCD11, ABCD12, ABCD13...)
 		"dataFinal":            []string{time.Now().Format("02/01/2006")},
 		"dataInicial":          []string{nMonthAgo.Format("02/01/2006")},
-        "o[0][dataReferencia]"	[]string{"asc"},
+        "o[0][dataReferencia]":	[]string{"asc"},
 		"_":                    []string{timestamp},
 	}
 

--- a/fetch/fetch_fii.go
+++ b/fetch/fetch_fii.go
@@ -378,9 +378,10 @@ func (fii *FII) reportIDs(rt repType, code string, n int) ([]id, error) {
 		"idEspecieDocumento":   []string{"0"},
 		"situacao":             []string{"A"},
 		"s":                    []string{"0"},
-		"l":                    []string{strconv.Itoa(n * 2)}, // 'n*2' latest reports as other codes may appear (e.g.:ABCD11, ABCD12, ABCD13...)
+		"l":                    []string{"200"}, // 'n*2' latest reports as other codes may appear (e.g.:ABCD11, ABCD12, ABCD13...)
 		"dataFinal":            []string{time.Now().Format("02/01/2006")},
 		"dataInicial":          []string{nMonthAgo.Format("02/01/2006")},
+        "o[0][dataReferencia]"	[]string{"asc"},
 		"_":                    []string{timestamp},
 	}
 


### PR DESCRIPTION
A API da **bmfbovespa** não permite requisitar mais que 200 ids de arquivo. Como a variável `l = n*2`, caso seja requisitado mais que 100 meses é obtido o error `{"msg":"O limite de itens para pesquisas é 200!","dados":null,"erros":null}`