### PR TITLE
novo layout do html de dividendos e inclusão de FiI Agro e Infra

### DIFF
--- a/fetch/fetch_fii.go
+++ b/fetch/fetch_fii.go
@@ -381,7 +381,7 @@ func (fii *FII) reportIDs(rt repType, code string, n int) ([]id, error) {
 		"l":                    []string{"200"}, // 'n*2' latest reports as other codes may appear (e.g.:ABCD11, ABCD12, ABCD13...)
 		"dataFinal":            []string{time.Now().Format("02/01/2006")},
 		"dataInicial":          []string{nMonthAgo.Format("02/01/2006")},
-        "o[0][dataReferencia]"	[]string{"asc"},
+        "o[0][dataReferencia]":	[]string{"asc"},
 		"_":                    []string{timestamp},
 	}
 

--- a/fetch/fetch_fii.go
+++ b/fetch/fetch_fii.go
@@ -378,9 +378,10 @@ func (fii *FII) reportIDs(rt repType, code string, n int) ([]id, error) {
 		"idEspecieDocumento":   []string{"0"},
 		"situacao":             []string{"A"},
 		"s":                    []string{"0"},
-		"l":                    []string{strconv.Itoa(n * 2)}, // 'n*2' latest reports as other codes may appear (e.g.:ABCD11, ABCD12, ABCD13...)
+		"l":                    []string{"200"}, // 'n*2' latest reports as other codes may appear (e.g.:ABCD11, ABCD12, ABCD13...)
 		"dataFinal":            []string{time.Now().Format("02/01/2006")},
 		"dataInicial":          []string{nMonthAgo.Format("02/01/2006")},
+        "o[0][dataReferencia]"	[]string{"asc"},
 		"_":                    []string{timestamp},
 	}
 

--- a/fetch/fetch_fii.go
+++ b/fetch/fetch_fii.go
@@ -173,7 +173,7 @@ func (fii *FII) dividendReport(code string, ids []id) (*[]rapina.Dividend, error
 				if fieldName == "" {
 					fieldName = v
 				} else {
-					if strings.Contains(fieldName, "Código de negociação da cota") ||
+					if strings.Contains(fieldName, "Código de negociação") ||
 						strings.Contains(fieldName, "Data da informação") {
 						progress.Debug("[%s] %-30s => %s\n", code, fieldName, v)
 					}

--- a/parsers/fiidb.go
+++ b/parsers/fiidb.go
@@ -164,7 +164,7 @@ func (fii *FIIParser) SaveDividend(stream map[string]string) (*rapina.Dividend, 
 	code := mapFinder("Código de negociação da cota", stream)
 	baseDate := fixDate(mapFinder("Data-base", stream))
 	pymtDate := fixDate(mapFinder("Data do pagamento", stream))
-	val := mapFinder("Valor do provento por cota", stream)
+	val := mapFinder("Valor do provento", stream)
 	fVal := comma2dot(val)
 
 	fii.mu.Lock()

--- a/parsers/stock.go
+++ b/parsers/stock.go
@@ -426,7 +426,7 @@ func parseB3Quote(line string) (*stockQuote, error) {
 	}
 
 	codBDI := line[10:12]
-	if codBDI != "02" && codBDI != "12" && codBDI != "13" {
+	if codBDI != "02" && codBDI != "12" && codBDI != "13" && codBDI != "14" {
 		return nil, fmt.Errorf("BDI %s ignorado", codBDI)
 	}
 

--- a/parsers/stock.go
+++ b/parsers/stock.go
@@ -426,7 +426,7 @@ func parseB3Quote(line string) (*stockQuote, error) {
 	}
 
 	codBDI := line[10:12]
-	if codBDI != "02" && codBDI != "12" {
+	if codBDI != "02" && codBDI != "12" && codBDI != "13" {
 		return nil, fmt.Errorf("BDI %s ignorado", codBDI)
 	}
 


### PR DESCRIPTION
1) Mudança do layout do relatório html dos dividendos 
   - de:
	https://fnet.bmfbovespa.com.br/fnet/publico/exibirDocumento?id=11052&cvm=true

   - para: 
	https://fnet.bmfbovespa.com.br/fnet/publico/exibirDocumento?id=363268&cvm=true


2) Inclusão de código BDI (13 e 14) para fii Agro e fi Infra respectivamente ( Mudança ainda não refletida no layout da b3, para os fii Agro https://www.b3.com.br/data/files/33/67/B9/50/D84057102C784E47AC094EA8/SeriesHistoricas_Layout.pdf )